### PR TITLE
Mobile menu improvements

### DIFF
--- a/components/header.tsx
+++ b/components/header.tsx
@@ -22,9 +22,14 @@ export default function Header() {
   };
 
   useEffect(() => {
-    router.events.on("routeChangeComplete", toggleMenu);
+    const onRouterChange = () => {
+      setActive(!isActive)
+      document?.body?.classList?.remove?.("overflow-hidden");
+    }
+
+    router.events.on("routeChangeComplete", onRouterChange);
     return () => {
-      router.events.off("routeChangeComplete", toggleMenu);
+      router.events.off("routeChangeComplete", onRouterChange);
     };
   }, [router.events]);
 
@@ -63,29 +68,29 @@ export default function Header() {
           alignItems: "center",
         }}
       >
-        <Link href="/" passHref>
+        <Link activeClassName='active' href="/" passHref>
           <NavLink sx={mobileLinksStyle}>Home</NavLink>
         </Link>
-        <Link href="/dove-siamo" passHref>
+        <Link activeClassName='active' href="/dove-siamo" passHref>
           <NavLink sx={mobileLinksStyle}>Dove Siamo</NavLink>
         </Link>
-        <Link href="/chi-siamo" passHref>
+        <Link activeClassName='active' href="/chi-siamo" passHref>
           <NavLink sx={mobileLinksStyle}>Chi Siamo</NavLink>
         </Link>
-        <Link href="/cosa-facciamo" passHref>
+        <Link activeClassName='active' href="/cosa-facciamo" passHref>
           <NavLink sx={mobileLinksStyle}>Cosa Facciamo</NavLink>
         </Link>
-        <Link href="/contatti" passHref>
+        <Link activeClassName='active' href="/contatti" passHref>
           <NavLink sx={mobileLinksStyle}>Contatti</NavLink>
         </Link>
-        <Link href="/categorie-prodotti" passHref>
+        <Link activeClassName='active' href="/categorie-prodotti" passHref>
           <NavLink sx={mobileLinksStyle}>Prodotti</NavLink>
         </Link>
-        <Link href="/faq" passHref>
+        <Link activeClassName='active' href="/faq" passHref>
           <NavLink sx={mobileLinksStyle}>FAQ</NavLink>
         </Link>
 
-        <Link href="/news" passHref>
+        <Link activeClassName='active' href="/news" passHref>
           <NavLink sx={mobileLinksStyle}>News</NavLink>
         </Link>
       </Box>

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -13,11 +13,9 @@ const mobileLinksStyle = {
 export default function Header() {
   const [isActive, setActive] = useState(false);
   const toggleMenu = () => {
-    if (isActive) {
-      document?.body?.classList?.remove?.("overflow-hidden");
-    } else {
-      document?.body?.classList?.add?.("overflow-hidden");
-    }
+    const method = isActive ? 'remove' : 'add';
+    document?.body?.classList?.[method]("overflow-hidden");
+
     setActive(!isActive);
   };
 
@@ -57,29 +55,29 @@ export default function Header() {
         }}
       >
         <Link href="/" passHref>
-          <NavLink sx={mobileLinksStyle}>Home</NavLink>
+          <NavLink onClick={toggleMenu} sx={mobileLinksStyle}>Home</NavLink>
         </Link>
         <Link href="/dove-siamo" passHref>
-          <NavLink sx={mobileLinksStyle}>Dove Siamo</NavLink>
+          <NavLink onClick={toggleMenu} sx={mobileLinksStyle}>Dove Siamo</NavLink>
         </Link>
         <Link href="/chi-siamo" passHref>
-          <NavLink sx={mobileLinksStyle}>Chi Siamo</NavLink>
+          <NavLink onClick={toggleMenu} sx={mobileLinksStyle}>Chi Siamo</NavLink>
         </Link>
         <Link href="/cosa-facciamo" passHref>
-          <NavLink sx={mobileLinksStyle}>Cosa Facciamo</NavLink>
+          <NavLink onClick={toggleMenu} sx={mobileLinksStyle}>Cosa Facciamo</NavLink>
         </Link>
         <Link href="/contatti" passHref>
-          <NavLink sx={mobileLinksStyle}>Contatti</NavLink>
+          <NavLink onClick={toggleMenu} sx={mobileLinksStyle}>Contatti</NavLink>
         </Link>
         <Link href="/categorie-prodotti" passHref>
-          <NavLink sx={mobileLinksStyle}>Prodotti</NavLink>
+          <NavLink onClick={toggleMenu} sx={mobileLinksStyle}>Prodotti</NavLink>
         </Link>
         <Link href="/faq" passHref>
-          <NavLink sx={mobileLinksStyle}>FAQ</NavLink>
+          <NavLink onClick={toggleMenu} sx={mobileLinksStyle}>FAQ</NavLink>
         </Link>
 
         <Link href="/news" passHref>
-          <NavLink sx={mobileLinksStyle}>News</NavLink>
+          <NavLink onClick={toggleMenu} sx={mobileLinksStyle}>News</NavLink>
         </Link>
       </Box>
       <MenuButton
@@ -95,6 +93,6 @@ export default function Header() {
           },
         }}
       />
-    </Flex>
+    </Flex >
   );
 }

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -1,7 +1,8 @@
 import Link from "next/link";
 import { Flex, Image, NavLink, MenuButton, Box } from "theme-ui";
 
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
+import { useRouter } from 'next/router'
 
 const mobileLinksStyle = {
   fontSize: [3, null, 2],
@@ -11,6 +12,7 @@ const mobileLinksStyle = {
 };
 
 export default function Header() {
+  const router = useRouter();
   const [isActive, setActive] = useState(false);
   const toggleMenu = () => {
     const method = isActive ? 'remove' : 'add';
@@ -18,6 +20,13 @@ export default function Header() {
 
     setActive(!isActive);
   };
+
+  useEffect(() => {
+    router.events.on("routeChangeComplete", toggleMenu);
+    return () => {
+      router.events.off("routeChangeComplete", toggleMenu);
+    };
+  }, [router.events]);
 
   return (
     <Flex
@@ -55,29 +64,29 @@ export default function Header() {
         }}
       >
         <Link href="/" passHref>
-          <NavLink onClick={toggleMenu} sx={mobileLinksStyle}>Home</NavLink>
+          <NavLink sx={mobileLinksStyle}>Home</NavLink>
         </Link>
         <Link href="/dove-siamo" passHref>
-          <NavLink onClick={toggleMenu} sx={mobileLinksStyle}>Dove Siamo</NavLink>
+          <NavLink sx={mobileLinksStyle}>Dove Siamo</NavLink>
         </Link>
         <Link href="/chi-siamo" passHref>
-          <NavLink onClick={toggleMenu} sx={mobileLinksStyle}>Chi Siamo</NavLink>
+          <NavLink sx={mobileLinksStyle}>Chi Siamo</NavLink>
         </Link>
         <Link href="/cosa-facciamo" passHref>
-          <NavLink onClick={toggleMenu} sx={mobileLinksStyle}>Cosa Facciamo</NavLink>
+          <NavLink sx={mobileLinksStyle}>Cosa Facciamo</NavLink>
         </Link>
         <Link href="/contatti" passHref>
-          <NavLink onClick={toggleMenu} sx={mobileLinksStyle}>Contatti</NavLink>
+          <NavLink sx={mobileLinksStyle}>Contatti</NavLink>
         </Link>
         <Link href="/categorie-prodotti" passHref>
-          <NavLink onClick={toggleMenu} sx={mobileLinksStyle}>Prodotti</NavLink>
+          <NavLink sx={mobileLinksStyle}>Prodotti</NavLink>
         </Link>
         <Link href="/faq" passHref>
-          <NavLink onClick={toggleMenu} sx={mobileLinksStyle}>FAQ</NavLink>
+          <NavLink sx={mobileLinksStyle}>FAQ</NavLink>
         </Link>
 
         <Link href="/news" passHref>
-          <NavLink onClick={toggleMenu} sx={mobileLinksStyle}>News</NavLink>
+          <NavLink sx={mobileLinksStyle}>News</NavLink>
         </Link>
       </Box>
       <MenuButton

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -6,7 +6,8 @@ import React, { useState } from "react";
 const mobileLinksStyle = {
   fontSize: [3, null, 2],
   my: [2, null, 0],
-  p: 2,
+  py: [1, 2],
+  px: 2,
 };
 
 export default function Header() {

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -9,10 +9,7 @@ import "styles/global.css";
 function MyApp({ Component, pageProps }) {
   const router = useRouter();
   useEffect(() => {
-    const handleRouteChange = (url) => {
-      gtag.pageview(url);
-      document?.body?.classList?.remove?.("overflow-hidden");
-    };
+    const handleRouteChange = (url) => gtag.pageview(url);
     router.events.on("routeChangeComplete", handleRouteChange);
     return () => {
       router.events.off("routeChangeComplete", handleRouteChange);


### PR DESCRIPTION
> scroll is not disabled for touch screen devices

**Unreplicable.**

> on iphone se 2020 (not tested on other models) some links go on top of the logo, need to make space between links smaller or remove logo, not sure what's best

Should be fixed.

> clicking on same page link should close the menu, right now cause incorrect behaviour. The menu doesn't close and once you close manually the body is not scrollable

Should be fixed.